### PR TITLE
Support Android 11 changes related to package visibility. These changes affect apps only if they target Android 11(API 30).

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ echo clientId=\"put your production clientId here\" > sample-bikeshop/bikeshop.p
 Build the SDK and the sample app:
 
 ```
-./gradlew sample-hellocharge:build
+./gradlew :sample-hellocharge:build
 ```
 
 Add the [SHA1 fingerprint](https://docs.connect.squareup.com/articles/android-app-fingerprint/) of the sample app to your application dashboard:

--- a/build.gradle
+++ b/build.gradle
@@ -28,15 +28,15 @@ subprojects {
       jcenter()
     }
     dependencies {
-      classpath 'com.android.tools.build:gradle:3.4.2'
-      classpath 'com.google.gms:google-services:3.0.0'
+      classpath 'com.android.tools.build:gradle:4.2.2'
+      classpath 'com.google.gms:google-services:4.3.10'
     }
   }
 }
 
 ext {
   minSdkVersion = 17
-  compileSdkVersion = 28
+  compileSdkVersion = 30
   targetSdkVersion = compileSdkVersion
   javaVersion = JavaVersion.VERSION_1_7
   GROUP = 'com.squareup.sdk'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/point-of-sale-sdk/src/main/AndroidManifest.xml
+++ b/point-of-sale-sdk/src/main/AndroidManifest.xml
@@ -18,4 +18,9 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.squareup.sdk.pos"
     >
+  <queries>
+    <intent>
+      <action android:name="com.squareup.pos.action.CHARGE" />
+    </intent>
+  </queries>
 </manifest>


### PR DESCRIPTION
Support Android 11 changes related to package visibility. These changes affect apps only if they target Android 11(API 30).
- Set targetSdkVersion to API 30.
- Bumped gradle plugin to 4.3.10
- Bumped gradle to 6.7.1