### PR TITLE
[R2-2484] Add PayPay tender type to POS API

### DIFF
--- a/point-of-sale-sdk/src/main/java/com/squareup/sdk/pos/ChargeRequest.java
+++ b/point-of-sale-sdk/src/main/java/com/squareup/sdk/pos/ChargeRequest.java
@@ -30,6 +30,7 @@ import static com.squareup.sdk.pos.PosApi.EXTRA_TENDER_CARD;
 import static com.squareup.sdk.pos.PosApi.EXTRA_TENDER_CARD_ON_FILE;
 import static com.squareup.sdk.pos.PosApi.EXTRA_TENDER_CASH;
 import static com.squareup.sdk.pos.PosApi.EXTRA_TENDER_OTHER;
+import static com.squareup.sdk.pos.PosApi.EXTRA_TENDER_PAYPAY;
 import static com.squareup.sdk.pos.PosSdkHelper.nonNull;
 import static java.util.Collections.unmodifiableSet;
 
@@ -517,13 +518,13 @@ public final class ChargeRequest {
     /** Allow Card On File transactions. */
     CARD_ON_FILE(EXTRA_TENDER_CARD_ON_FILE),
 
-    /** Allow Cash transactions. Useful to keep all payment records in one place. */
+    /** Allow Cash transactions. */
     CASH(EXTRA_TENDER_CASH),
 
-    /**
-     * Allow Check, Third-Party Gift Cards, and Other Tender transactions. Useful to keep all
-     * payment records in one place.
-     */
+    /** Allow PayPay transactions. */
+    PAYPAY(EXTRA_TENDER_PAYPAY),
+
+    /** Allow Check, Third-Party Gift Cards, and Other Tender transactions. */
     OTHER(EXTRA_TENDER_OTHER);
 
     String apiExtraName;

--- a/point-of-sale-sdk/src/main/java/com/squareup/sdk/pos/PosApi.java
+++ b/point-of-sale-sdk/src/main/java/com/squareup/sdk/pos/PosApi.java
@@ -52,6 +52,8 @@ public final class PosApi {
 
   public static final String EXTRA_TENDER_CASH = NAMESPACE + "TENDER_CASH";
 
+  public static final String EXTRA_TENDER_PAYPAY = NAMESPACE + "TENDER_PAYPAY";
+
   public static final String EXTRA_TENDER_OTHER = NAMESPACE + "TENDER_OTHER";
 
   public static final String EXTRA_TENDER_CARD_ON_FILE = NAMESPACE + "TENDER_CARD_ON_FILE";

--- a/point-of-sale-sdk/src/test/java/com/squareup/sdk/pos/ChargeRequestTest.java
+++ b/point-of-sale-sdk/src/test/java/com/squareup/sdk/pos/ChargeRequestTest.java
@@ -22,6 +22,7 @@ import static com.squareup.sdk.pos.ChargeRequest.TenderType.CARD;
 import static com.squareup.sdk.pos.ChargeRequest.TenderType.CARD_ON_FILE;
 import static com.squareup.sdk.pos.ChargeRequest.TenderType.CASH;
 import static com.squareup.sdk.pos.ChargeRequest.TenderType.OTHER;
+import static com.squareup.sdk.pos.ChargeRequest.TenderType.PAYPAY;
 import static com.squareup.sdk.pos.CurrencyCode.CAD;
 import static com.squareup.sdk.pos.CurrencyCode.USD;
 import static com.squareup.sdk.pos.PosApi.AUTO_RETURN_NO_TIMEOUT;
@@ -42,7 +43,7 @@ public class ChargeRequestTest {
 
   @Test public void requestHasAllTenderTypesByDefault() {
     ChargeRequest request = new ChargeRequest.Builder(1_00, USD).build();
-    assertThat(request.tenderTypes).containsOnly(CARD, CARD_ON_FILE, CASH, OTHER);
+    assertThat(request.tenderTypes).containsOnly(CARD, CARD_ON_FILE, CASH, PAYPAY, OTHER);
   }
 
   @Test public void requestHasNoTimeoutByDefault() {

--- a/sample-bikeshop/src/main/java/com/example/owensbikes/MainActivity.java
+++ b/sample-bikeshop/src/main/java/com/example/owensbikes/MainActivity.java
@@ -38,6 +38,7 @@ import java.util.concurrent.TimeUnit;
 import static android.content.res.Configuration.ORIENTATION_LANDSCAPE;
 import static com.squareup.sdk.pos.ChargeRequest.TenderType.CARD;
 import static com.squareup.sdk.pos.ChargeRequest.TenderType.CASH;
+import static com.squareup.sdk.pos.ChargeRequest.TenderType.PAYPAY;
 
 public class MainActivity extends AppCompatActivity {
 
@@ -115,7 +116,7 @@ public class MainActivity extends AppCompatActivity {
   public void checkout() {
     int amount = itemManager.getTotal();
     String note = itemManager.getNote();
-    Set<ChargeRequest.TenderType> tenderTypes = EnumSet.of(CARD, CASH);
+    Set<ChargeRequest.TenderType> tenderTypes = EnumSet.of(CARD, CASH, PAYPAY);
     // Order number is an integer stored in a SharedPreference as an example of
     // requestMetadata usage.
     long orderNumber = orderInfoPrefs.getLong(ORDER_NUMBER, FIRST_ORDER_NUMBER) + 1;

--- a/sample-hellocharge/src/main/java/com/example/hellocharge/HelloChargeActivity.java
+++ b/sample-hellocharge/src/main/java/com/example/hellocharge/HelloChargeActivity.java
@@ -53,6 +53,7 @@ public class HelloChargeActivity extends AppCompatActivity {
   private CheckBox cardCheckbox;
   private CheckBox cashCheckbox;
   private CheckBox cardOnFileCheckbox;
+  private CheckBox payPayCheckbox;
   private CheckBox otherTenderCheckbox;
   private EditText locationIdEditText;
   private EditText customerIdEditText;
@@ -72,6 +73,7 @@ public class HelloChargeActivity extends AppCompatActivity {
     cardCheckbox = findView(R.id.card_tender_checkbox);
     cashCheckbox = findView(R.id.cash_tender_checkbox);
     cardOnFileCheckbox = findView(R.id.card_on_file_checkbox);
+    payPayCheckbox = findView(R.id.paypay_checkbox);
     otherTenderCheckbox = findView(R.id.other_tender_checkbox);
     locationIdEditText = findView(R.id.location_id_edit_text);
     customerIdEditText = findView(R.id.customer_id_edit_text);
@@ -115,6 +117,9 @@ public class HelloChargeActivity extends AppCompatActivity {
     }
     if (cardOnFileCheckbox.isChecked()) {
       tenderTypes.add(ChargeRequest.TenderType.CARD_ON_FILE);
+    }
+    if (payPayCheckbox.isChecked()) {
+      tenderTypes.add(ChargeRequest.TenderType.PAYPAY);
     }
     if (otherTenderCheckbox.isChecked()) {
       tenderTypes.add(ChargeRequest.TenderType.OTHER);

--- a/sample-hellocharge/src/main/res/layout/hello_charge_activity.xml
+++ b/sample-hellocharge/src/main/res/layout/hello_charge_activity.xml
@@ -112,49 +112,50 @@
       <LinearLayout
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
-          android:orientation="horizontal"
+          android:orientation="vertical"
       >
 
         <CheckBox
             android:id="@+id/card_tender_checkbox"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
+            android:layout_width="wrap_content"
+            android:layout_height="0dp"
             android:layout_weight="1"
-            android:layout_marginTop="@dimen/vertical_space"
-            android:layout_marginBottom="@dimen/vertical_space"
             android:text="@string/card_text"
             android:checked="true"
         />
 
         <CheckBox
             android:id="@+id/cash_tender_checkbox"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
+            android:layout_width="wrap_content"
+            android:layout_height="0dp"
             android:layout_weight="1"
-            android:layout_marginTop="@dimen/vertical_space"
-            android:layout_marginBottom="@dimen/vertical_space"
             android:text="@string/cash_text"
             android:checked="true"
         />
 
         <CheckBox
             android:id="@+id/card_on_file_checkbox"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
+            android:layout_width="wrap_content"
+            android:layout_height="0dp"
             android:layout_weight="1"
-            android:layout_marginTop="@dimen/vertical_space"
-            android:layout_marginBottom="@dimen/vertical_space"
             android:text="@string/card_on_file_text"
             android:checked="true"
         />
 
         <CheckBox
-            android:id="@+id/other_tender_checkbox"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
+            android:id="@+id/paypay_checkbox"
+            android:layout_width="wrap_content"
+            android:layout_height="0dp"
             android:layout_weight="1"
-            android:layout_marginTop="@dimen/vertical_space"
-            android:layout_marginBottom="@dimen/vertical_space"
+            android:text="@string/paypay_text"
+            android:checked="true"
+            />
+
+        <CheckBox
+            android:id="@+id/other_tender_checkbox"
+            android:layout_width="wrap_content"
+            android:layout_height="0dp"
+            android:layout_weight="1"
             android:text="@string/other_tender_text"
             android:checked="true"
         />

--- a/sample-hellocharge/src/main/res/values/strings.xml
+++ b/sample-hellocharge/src/main/res/values/strings.xml
@@ -30,6 +30,7 @@
   <string name="note_default">Build with Square</string>
   <string name="note_hint">Note (optional)</string>
   <string name="other_tender_text">Other Tenders</string>
+  <string name="paypay_text">PayPay</string>
   <string name="tender_header">Tender Types</string>
   <string name="transaction_amount_default">100</string>
   <string name="transaction_amount_hint">Transaction Amount (cents)</string>


### PR DESCRIPTION
* Add PayPay tender type
* Change tender types view to vertical list (too many tender types now for horizontal)

![Screenshot_20230417_152238](https://user-images.githubusercontent.com/107430122/232590346-4a24b061-de2f-4c84-b09f-74668061f2f7.png)
