### PR TITLE
Updating RealPosClient to accept _either_ of the two keys Square uses

### DIFF
--- a/sample-hellocharge/build.gradle
+++ b/sample-hellocharge/build.gradle
@@ -18,6 +18,10 @@ apply plugin: 'com.android.application'
 apply plugin: 'org.jetbrains.kotlin.android'
 
 dependencies {
+  // This is configured to build the sample against the published POS SDK.
+  // If you instead want to work on the SDK itself, and use the sample to test
+  // that, uncomment the line below and comment out the one after it:
+  //   implementation project(':point-of-sale-sdk')
   implementation "com.squareup.sdk:point-of-sale-sdk:2.1"
   implementation "androidx.appcompat:appcompat:1.6.1"
   implementation "com.google.android.material:material:1.9.0"


### PR DESCRIPTION
The original key is used in the Play Store packages, but the other can be used to sign APKs not distributed from Google.